### PR TITLE
feat: Integrate venv activation and CLI command execution into VSCode…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ this means we are private - no company security risk. We can run on no internet.
      - `OPENAI_API_KEY=your-key-here`
      - `GENAI_API_KEY=your-key-here`
    - Option 2: set the API key, `export OPENAI_API_KEY=your-key-here`
-8. Run code with `python src/gcpc.py (--staged)`
+8. depricated ~~Run code with `python src/gcpc.py (--staged)`~~
 9. `pip install -e .` for editable mode installation of `gcpc` and other CLI tools for dev.
+10. Run commands from CLI (`gcpc`, `gcpull`, `gccommit`, etc)
 
 ## Extension Setup
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,10 @@ this is bootstrapped alternative to github ticketing / jira board
 
 ### General
 
+- [ ] 0.5 We might want to refactor our CLI commands to something like `gc pull` and `gc pc` instead of all one word
+  - [ ] This seems more like `gc` CLI package, instead of a bunch of standalone commands
+  - [ ] kinda like `git pull`, `git clone`, etc...
+
 - [ ] 1. Add functionality for pull update summary.
 
   - [x] `git diff HEAD@{1} HEAD` functionality

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -16,7 +16,7 @@
         "eslint": "^9.23.0"
       },
       "engines": {
-        "vscode": "^1.99.0"
+        "vscode": "^1.0.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/src/gittercommitter/gccommit.py
+++ b/src/gittercommitter/gccommit.py
@@ -11,7 +11,10 @@ def main(staged, model):
     """Generate commit message using the selected LLM."""
     diff_text = get_git_diff_gcpc(staged=staged)
     if not diff_text.strip():
-        click.secho("No diff found.", fg="yellow")
+        if staged:
+            click.secho("No staged changes found.", fg="yellow")
+        else:
+            click.secho("No diff found.", fg="yellow")
         return
     
     changed_files = collections.defaultdict(list)

--- a/src/gittercommitter/gcpc.py
+++ b/src/gittercommitter/gcpc.py
@@ -11,7 +11,10 @@ def main(staged, model):
     """Generate a behavioral summary of the git diff using the selected LLM."""
     diff_text = get_git_diff_gcpc(staged=staged)
     if not diff_text.strip():
-        click.secho("No diff found.", fg="yellow")
+        if staged:
+            click.secho("No staged changes found.", fg="yellow")
+        else:
+            click.secho("No diff found.", fg="yellow")
         return
     
     changed_files = collections.defaultdict(list)

--- a/src/gittercommitter/gcpull.py
+++ b/src/gittercommitter/gcpull.py
@@ -10,7 +10,7 @@ def main(model):
     """Generate a behavioral summary of the git diff using the selected LLM."""
     diff_text = get_git_diff_gcpull()
     if not diff_text.strip():
-        click.secho("No diff found.", fg="yellow")
+        click.secho("No pull diff found.", fg="yellow")
         return
 
     changed_files = collections.defaultdict(list)


### PR DESCRIPTION
… extension and add gccommit CLI

This commit introduces the following changes:

- Enhances the VSCode extension to automatically activate the virtual environment (venv) before executing CLI commands, ensuring the correct environment is used for gcpc.
- Adds logic to check for venv and act accordingly on Windows and Linux/Mac.
- Adds `gccommit` CLI command for generating commit messages using LLMs, including options for staged changes and model selection.
- Updates gcpc and gccommit to print a message if no diff found, staged or not, for better user experience.
- Updates README.md to add to CLI usage instructions.
- Updates TODO.md for possible CLI reformatting.


Super hacky, dev purpose solution for extension.
Need to finish CLI tool. Ship to prod, then use extension to call installed version of CLI tool.
This mirrors extensions like Gitlens, Jupyter, and others.